### PR TITLE
docs: fix directory name in Zenodo packaging instructions

### DIFF
--- a/tutorial/src/developer-notes.md
+++ b/tutorial/src/developer-notes.md
@@ -270,7 +270,7 @@ VEXRISCV_REGRESSION_SEED=42 VEXRISCV_REGRESSION_LINUX_REGRESSION=no VEXRISCV_REG
 To prepare the package by removing all the irrelevant files:
 
 ```sh
-cd artifacts
+cd artifact
 make partial-clean
 # make sure the correct Vivado projects are included
 du -sh  # should be something close to 39G


### PR DESCRIPTION
The developer notes say `cd artifacts` before `make partial-clean`, but the folder is `artifact` (singular) — the `partial-clean` target is defined in `artifact/Makefile`. This fixes the directory name; the rest of the block (`cd ../..` then `tar`) is consistent with the corrected path.