### PR TITLE
docs: fix path to build_micro_blossom.py in VMK180 README

### DIFF
--- a/src/fpga/Xilinx/VMK180_Micro_Blossom/README.md
+++ b/src/fpga/Xilinx/VMK180_Micro_Blossom/README.md
@@ -1,6 +1,6 @@
 # VMK180 Micro Blossom
 
-Note: to customize the module and create a project out of it, use `/src/fpga/utils.build_micro_blossom.py`.
+Note: to customize the module and create a project out of it, use `/src/fpga/utils/build_micro_blossom.py`.
 
 ## Usage
 


### PR DESCRIPTION
The VMK180 README points to `/src/fpga/utils.build_micro_blossom.py`, but the script lives in the `utils/` directory: `src/fpga/utils/build_micro_blossom.py`. This replaces the dot with a slash.