### PR TITLE
docs: fix typos in README and developer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A highly configurable hardware-accelerated Minimum-Weight Perfect Matching (MWPM
 
 Paper coming soon!!! Stay tuned!!!
 
-Micro Blossom is a heterogenous architecture that solves **exact** MWPM decoding problem in sub-microsecond latency by
+Micro Blossom is a heterogeneous architecture that solves **exact** MWPM decoding problem in sub-microsecond latency by
 taking advantage of vertex and edge-level fine-grained hardware acceleration.
 At the heart of Micro Blossom is an algorithm (equivalent to the original blossom algorithm) specifically optimized for resource-efficient RTL (register transfer level) implementation, with compact combinational logic and pipeline design.
 Given an arbitrary decoding graph, Micro Blossom automatically generates a hardware implementation (either Verilog or VHDL depending on your needs).

--- a/src/cpu/embedded/README.md
+++ b/src/cpu/embedded/README.md
@@ -53,7 +53,7 @@ make Xilinx  # build static library for both aarch64 and armv7r
 
 There are several projects in `src/fpga/Xilinx` folder, see `src/fpga/Xilinx/README.md` for more information.
 As an example, the following command will build the whole image of a simple application with 2GB LPDDR4 and 8KB BRAM on the PL
-side shared by both A72 and R5F in the Versal VMK180 evaluation borad.
+side shared by both A72 and R5F in the Versal VMK180 evaluation board.
 Note that the BRAM is configured to be dual port, so although A72 accesses it using `0xA400_0000` while R5F accesses it using
 `0x8000_0000`, they are essentially the same memory.
 
@@ -65,7 +65,7 @@ make -C ../../fpga/Xilinx/VMK180_BRAM
 # flash the image and run the program
 make -C ../../fpga/Xilinx/VMK180_BRAM run_r5
 make -C ../../fpga/Xilinx/VMK180_BRAM run_a72
-# if the hardware XSA is not changed, we can avoid reseting the whole system but only reload CPU program
+# if the hardware XSA is not changed, we can avoid resetting the whole system but only reload CPU program
 make -C ../../fpga/Xilinx/VMK180_BRAM run_r5_q
 make -C ../../fpga/Xilinx/VMK180_BRAM run_a72_q
 ```

--- a/tutorial/src/developer-notes.md
+++ b/tutorial/src/developer-notes.md
@@ -53,7 +53,7 @@ when I run `openocd -c 'set VEXRISCV_YAML ../VexRiscv/cpu0.yaml' -f tcl/target/v
 
 **Update**: OpenOCD uses GDB instead of LLDB, but GDB does not support apple silicon, only x86. Thus, it is impossible to
 interactively debug the CPU with M1 Macs. However, the verilator and VexRiscV/SpinalHDL runs on M1 Macs without a problem.
-We can debug the design on a x86 Linux machine and do other staffs on Macs.
+We can debug the design on a x86 Linux machine and do other stuff on Macs.
 
 ```sh
 git clone git@github.com:SpinalHDL/openocd_riscv.git
@@ -289,7 +289,7 @@ sudo picocom /dev/ttyUSB1 -b 115200 --imap lfcrlf -g /home/ae/micro-blossom/src/
 ```
 
 We also need to set up access for the Digilent USB adaptor so that the new user can access the FPGA device via xsdb.
-This is a little bit trikky though, see [this post](https://blog.t123yh.xyz:2/index.php/archives/1013) for permitting multiple users to share the device:
+This is a little bit tricky though, see [this post](https://blog.t123yh.xyz:2/index.php/archives/1013) for permitting multiple users to share the device:
 
 ```sh
 sudo adduser $USER dialout  # add to the dialout group


### PR DESCRIPTION
Small documentation typo fixes:

- `README.md`: `heterogenous` → `heterogeneous`
- `tutorial/src/developer-notes.md`: `do other staffs` → `do other stuff`, `trikky` → `tricky`
- `src/cpu/embedded/README.md`: `evaluation borad` → `evaluation board`, `reseting` → `resetting`